### PR TITLE
Add on_server_ready update callback for vtkLocalView

### DIFF
--- a/trame_vtk/widgets/vtk/common.py
+++ b/trame_vtk/widgets/vtk/common.py
@@ -687,6 +687,7 @@ class VtkLocalView(HtmlElement):
             "EndInteraction",
         ]
         self.update()
+        self._server.controller.on_server_ready.add(self.update)
 
     def update(self, **kwargs):
         """


### PR DESCRIPTION
As discussed with @jourdain 

This line is critical for the `VtkLocalView` to work, so why not include it as default?