### PR TITLE
fix: Improve VTK error reporting capabilities

### DIFF
--- a/trame_vtk/modules/paraview/__init__.py
+++ b/trame_vtk/modules/paraview/__init__.py
@@ -1,6 +1,10 @@
 from ..vtk.core import HybridView
 
 
+def has_capabilities(*features):
+    pass
+
+
 class Helper:
     def __init__(self, app):
         self._root_protocol = None

--- a/trame_vtk/widgets/vtk/common.py
+++ b/trame_vtk/widgets/vtk/common.py
@@ -353,6 +353,8 @@ class VtkRemoteLocalView(HtmlElement):
 
         activate_module_for(self.server, view)
 
+        MODULE.has_capabilities("web", "rendering")
+
         __ns = kwargs.get("namespace", "view")
         self.__mode_key = f"{__ns}Mode"
         self.__scene_id = f"{__ns}Scene"
@@ -525,6 +527,8 @@ class VtkRemoteView(HtmlElement):
 
         activate_module_for(self.server, view)
 
+        MODULE.has_capabilities("web", "rendering")
+
         self.__view = view
         self.__ref = ref
         self.__view_key_id = f"{ref}Id"
@@ -629,6 +633,8 @@ class VtkLocalView(HtmlElement):
         super().__init__("vtk-local-view", **kwargs)
 
         activate_module_for(self.server, view)
+
+        MODULE.has_capabilities("web")
 
         self.__scene_id = f"scene_{ref}"
         self.__view = view


### PR DESCRIPTION
Resolves #2 

This removes the message that was printed on a failed import in favor of an actual `ImportError` when instantiated classes that require these modules.

Additionally, and this might not be needed or wanted, I changed the boolean value to be `HAS_VTK_WEB` while adding a new `HAS_VTK` boolean that evaluates whether VTK is installed at all and warns if not.

This will convienantly call out the issue with the conda-build at this time for conda users. Ref https://github.com/conda-forge/vtk-feedstock/pull/258