### PR TITLE
fix: support BigInt64Array and BigUint64Array

### DIFF
--- a/examples/validation/PyVistaInt64.py
+++ b/examples/validation/PyVistaInt64.py
@@ -1,0 +1,53 @@
+"""Validate Int64 usage with VTK.js."""
+
+import pyvista as pv
+import numpy as np
+from trame.app import get_server
+from trame.ui.vuetify import SinglePageLayout
+from trame.widgets import vuetify
+from trame.widgets.vtk import VtkLocalView
+
+server = get_server()
+state, ctrl = server.state, server.controller
+
+state.trame__title = "Int64 Validation"
+
+# -----------------------------------------------------------------------------
+
+mesh = pv.Sphere()
+mesh["data"] = np.arange(mesh.n_cells, dtype=np.int64)
+
+plotter = pv.Plotter(off_screen=True)
+actor = plotter.add_mesh(mesh, scalars="data")
+plotter.reset_camera()
+
+
+# -----------------------------------------------------------------------------
+# GUI
+# -----------------------------------------------------------------------------
+
+with SinglePageLayout(server) as layout:
+    layout.icon.click = ctrl.view_reset_camera
+    layout.title.set_text(state.trame__title)
+
+    with layout.toolbar:
+        vuetify.VSpacer()
+
+    with layout.content:
+        with vuetify.VContainer(
+            fluid=True,
+            classes="pa-0 fill-height",
+        ):
+            view = VtkLocalView(plotter.ren_win)
+            ctrl.view_update = view.update
+            ctrl.view_reset_camera = view.reset_camera
+
+    # hide footer
+    layout.footer.hide()
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    server.start()

--- a/trame_vtk/modules/vtk/addon_serializer.py
+++ b/trame_vtk/modules/vtk/addon_serializer.py
@@ -1,5 +1,15 @@
+from vtkmodules import web
 from vtkmodules.web import render_window_serializer
 from vtkmodules.vtkFiltersGeometry import vtkDataSetSurfaceFilter
+
+# Patch support for BigInt64 (VTK_LONG_LONG)
+# This requires the latest VTK.js
+if len(web.arrayTypesMapping) < 17:
+    # Mapping is done by index of the list
+    web.arrayTypesMapping.append("ll")  # VTK_LONG_LONG            16
+    web.arrayTypesMapping.append("LL")  # VTK_UNSIGNED_LONG_LONG   17
+    web.javascriptMapping["ll"] = "BigInt64Array"
+    web.javascriptMapping["LL"] = "BigUint64Array"
 
 
 def rgb_float_to_hex(r, g, b):

--- a/trame_vtk/modules/vtk/addon_serializer.py
+++ b/trame_vtk/modules/vtk/addon_serializer.py
@@ -4,7 +4,7 @@ from vtkmodules.vtkFiltersGeometry import vtkDataSetSurfaceFilter
 
 # Patch support for BigInt64 (VTK_LONG_LONG)
 # This requires the latest VTK.js
-if len(web.arrayTypesMapping) < 17:
+if len(web.arrayTypesMapping) == 16:
     # Mapping is done by index of the list
     web.arrayTypesMapping.append("ll")  # VTK_LONG_LONG            16
     web.arrayTypesMapping.append("LL")  # VTK_UNSIGNED_LONG_LONG   17


### PR DESCRIPTION
Resolves #21 and requires upstream support from VTK.js: https://github.com/Kitware/vtk-js/pull/2696

@jourdain, do we need to bump the VTK.js version (when released) used in vue-vtk-js and re-bundle it here?