### PR TITLE
fix(aiohttp): Limit aiohttp<3.9 for #55

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ keywords =
 packages = find:
 include_package_data = True
 install_requires =
+    aiohttp<3.9
     trame-client
 
 [semantic_release]


### PR DESCRIPTION
Limit the version of aiohttp to under 3.9 until #55 is addressed