### PR TITLE
Fix MD5 hashing is not allowed for FIPS

### DIFF
--- a/trame_vtk/modules/vtk/serializers/utils.py
+++ b/trame_vtk/modules/vtk/serializers/utils.py
@@ -48,7 +48,7 @@ def base64_encode(x):
 
 
 def hash_data_array(data_array):
-    hashed_bit = hashlib.md5(memoryview(data_array)).hexdigest()
+    hashed_bit = hashlib.md5(memoryview(data_array), usedforsecurity=False).hexdigest()
     type_code = array_types_mapping[data_array.GetDataType()]
     return "%s_%d%s" % (hashed_bit, data_array.GetSize(), type_code)
 


### PR DESCRIPTION
With FIPS mode the following error is thrown.
`ValueError: [digital envelope routines: EVP_DigestInit_ex] disabled for FIPS`