### PR TITLE
fix(serializer): register vtkCompositePolyDataMapper

### DIFF
--- a/trame_vtk/modules/vtk/serializers/initialize.py
+++ b/trame_vtk/modules/vtk/serializers/initialize.py
@@ -70,6 +70,7 @@ def initialize_serializers():
             "vtkImageDataMapper",
             "vtkOpenGLPolyDataMapper",
             "vtkCompositePolyDataMapper2",
+            "vtkCompositePolyDataMapper",
         ],
         # Volume mappers
         generic_volume_mapper_serializer: [
@@ -151,6 +152,7 @@ def initialize_serializers():
 
     js_classes = {
         "vtkMapper": [
+            "vtkCompositePolyDataMapper",
             "vtkCompositePolyDataMapper2",
             "vtkDataSetMapper",
             "vtkOpenGLPolyDataMapper",


### PR DESCRIPTION
The missing registration causes examples of pyvista that utilize multiblock to fail.
 These are currently broken see:
- https://github.com/pyvista/pyvista/issues/5437
- https://github.com/pyvista/pyvista/issues/5361

The suggested change fixes the issue. See the last two examples in https://pyvist-multiblock-examples-issues.netlify.app/some_plots.

The problem was found by exporting `export TRAME_SERIALIZE_DEBUG=1` and compiling via sphinx the above example.