### PR TITLE
chore(js):  Allow triggering release on external artifact `static_viewer.html`

### DIFF
--- a/.fetch_externals.sh
+++ b/.fetch_externals.sh
@@ -6,3 +6,7 @@ mkdir -p ./trame_vtk/modules/common/serve
 curl https://unpkg.com/vue-vtk-js@3.2.1 -Lo ./trame_vtk/modules/common/serve/trame-vtk.js
 # echo 19e7c20470b952cc7b38f1434180b5ec ./trame_vtk/modules/common/serve/trame-vtk.js | md5sum -c --status && echo OK
 curl https://kitware.github.io/vtk-js/examples/OfflineLocalView/OfflineLocalView.html -Lo ./trame_vtk/tools/static_viewer.html
+
+if ! sha256sum --check .static_viewer.sha256 ; then
+  echo "Hash for static_viewer.html differs, please update .static_viewer.sha256"
+fi

--- a/.static_viewer.sha256
+++ b/.static_viewer.sha256
@@ -1,0 +1,1 @@
+b757777855acdc69644186c0678fb8f15cd28614fc96454e567ee81ae57ff3be  ./trame_vtk/tools/static_viewer.html


### PR DESCRIPTION
Previously, when a new version of static_viewer.html is released on the master of vtk-js we couldn't trigger a release because we do not commit this file but rather grab it during release. 

This commit adds the hash of the latest version in a file and a hash check that runs during release but does not trigger a failure on a mismatch but rather a warning.
So now if static_viewer.html is updated on vtk-js:
- If we do not care `.fetch_externals.sh` will just emit a warning
- If we **do** care we update `.static_viewer.sha256 `and trigger a new release on trame-vtk even if no other `trame-vtk` change happened during last release.


cc: @jourdain 