### PR TITLE
fix(js): track hash of vue-vtk-js as well

### DIFF
--- a/.externals.sha256
+++ b/.externals.sha256
@@ -1,0 +1,2 @@
+b757777855acdc69644186c0678fb8f15cd28614fc96454e567ee81ae57ff3be  ./trame_vtk/tools/static_viewer.html
+9916a1d1889d8aa24a2fa946a263ba9700d7ec2940de992efcb449e6b9604fcd  ./trame_vtk/modules/common/serve/trame-vtk.js

--- a/.fetch_externals.sh
+++ b/.fetch_externals.sh
@@ -4,9 +4,8 @@ set -e
 
 mkdir -p ./trame_vtk/modules/common/serve
 curl https://unpkg.com/vue-vtk-js@3.2.1 -Lo ./trame_vtk/modules/common/serve/trame-vtk.js
-# echo 19e7c20470b952cc7b38f1434180b5ec ./trame_vtk/modules/common/serve/trame-vtk.js | md5sum -c --status && echo OK
 curl https://kitware.github.io/vtk-js/examples/OfflineLocalView/OfflineLocalView.html -Lo ./trame_vtk/tools/static_viewer.html
 
-if ! sha256sum --check .static_viewer.sha256 ; then
-  echo "Hash for static_viewer.html differs, please update .static_viewer.sha256"
+if ! sha256sum --check .externals.sha256 ; then
+  echo "Hash(es) for externals differs, please update .externals.sha256"
 fi

--- a/.static_viewer.sha256
+++ b/.static_viewer.sha256
@@ -1,1 +1,0 @@
-b757777855acdc69644186c0678fb8f15cd28614fc96454e567ee81ae57ff3be  ./trame_vtk/tools/static_viewer.html


### PR DESCRIPTION
Similar to offline_viewer.html we track and report mismatched hash of all external dependencies.
see also https://github.com/Kitware/trame-vtk/pull/70.

cc: @jourdain  This time committed as a `fix` to trigger a release.
