### PR TITLE
ci: fix failing deployment by updating the github workflow from cookiecutter's

### DIFF
--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -110,6 +110,7 @@ jobs:
     permissions:
       id-token: write # IMPORTANT: mandatory for trusted publishing
       contents: write # IMPORTANT: mandatory for making GitHub Releases
+      attestations: write # IMPORTANT: mandatory for attest build provenance
 
     steps:
       - name: Checkout

--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -9,18 +9,24 @@ on:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    env:
+      UV_PYTHON: "3.12"
     steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.12"
+          version: "0.8.12"
+          enable-cache: true
+
+      - name: Install the project
+        run: uv sync --all-extras --dev
 
       # Install and run pre-commit
       - run: |
-          pip install pre-commit
-          pre-commit install
-          pre-commit run --all-files
+          uv run pre-commit install
+          uv run pre-commit install --hook-type commit-msg
+          uv run pre-commit run --all-files
 
   pytest:
     name: Pytest ${{ matrix.config.name }}
@@ -46,10 +52,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -61,11 +67,11 @@ jobs:
       #     bash .fetch_externals.sh
       # -----------------------------------------------------------------------
 
-      - name: Install dependencies
-        run: |
-          pip install .[dev]
-          pip install -r tests/requirements.txt
-          playwright install
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.8.12"
+          enable-cache: true
 
       - name: Install OSMesa for Linux
         if: matrix.config.os == 'ubuntu-latest'
@@ -73,12 +79,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libosmesa6-dev
 
-      - name: Run Tests
+      - name: Install and Run Tests
         run: |
-          # Run the tests with coverage so we get a coverage report too
-          coverage run --source . -m pytest ./tests
-          # Print the coverage report
-          coverage report -m
+          uv sync --dev
+          uv pip install -r tests/requirements.txt
+          uv run playwright install
+          uv run pytest -s ./tests --cov=src --cov-report=xml
 
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v3
@@ -107,7 +113,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -117,10 +123,17 @@ jobs:
 
       - name: Python Semantic Release
         id: release
-        uses: relekang/python-semantic-release@v9.15.2
+        uses: python-semantic-release/python-semantic-release@v10.5.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Generate artifact attestation for sdist and wheel
+        if: steps.release.outputs.released == 'true'
+        uses: actions/attest-build-provenance@v4.1.0
+        with:
+          subject-path: "dist/*"
+
+      # https://docs.pypi.org/trusted-publishers/using-a-publisher/
       - name: Publish package distributions to PyPI
         if: steps.release.outputs.released == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,10 +97,8 @@ version_variables = [
 ]
 
 build_command = """
-    python -m pip install -e '.[build]'
-    uv lock --upgrade-package "$PACKAGE_NAME"
-    git add uv.lock
-    uv build
+    pip install build
+    python -m build
 """
 
 [tool.ruff.lint.pycodestyle]

--- a/src/trame_vtk/modules/vtk/serializers/data.py
+++ b/src/trame_vtk/modules/vtk/serializers/data.py
@@ -135,7 +135,7 @@ def imagedata_serializer(
     dataset_id,
     context,
     _depth,
-    requested_fields,  # noqa: ARG001
+    requested_fields=None,  # noqa: ARG001
 ):
     if hasattr(dataset, "GetDirectionMatrix"):
         direction = [dataset.GetDirectionMatrix().GetElement(0, i) for i in range(9)]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,6 @@
 coverage
 pytest-asyncio
+pytest-cov
 pytest-playwright
 pyvista[all]==0.47.3
 trame


### PR DESCRIPTION
Automatic deployment failed on last merge: https://github.com/Kitware/trame-vtk/actions/runs/26819578811/job/79070621138 because the PR https://github.com/Kitware/trame-vtk/pull/108 uses `uv` and the github workflow wasn't updated to install it.

- The volume rendering test failed because the `imagedata_serializer` function must have `requested_fields` as an optional argument with a default value (I broke that in my last PR https://github.com/Kitware/trame-vtk/pull/108)
- The pyproject which was updated using the cookiecutter's now uses `uv`, the github workflow wasn't updated with the cookiecutter's one so `uv` was not installed.

Here is the diff between the proposed  .github/workflows/test_and_release.yml here and the cookiecutter's one (modulo some spaces/line breaks).
```diff
--- .github/workflows/cookiecutters_test_and_release.yml        2026-06-03 11:39:24.601017588 +0200
+++ .github/workflows/test_and_release.yml      2026-06-03 15:33:33.933531850 +0200
@@ -1,101 +1,140 @@
 name: Test and Release
 
 on:
   push:
-    branches: [ main ]
+    branches: [master]
   pull_request:
-    branches: [ main ]
+    branches: [master]
 
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
     env:
       UV_PYTHON: "3.12"
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
           version: "0.8.12"
           enable-cache: true
 
       - name: Install the project
         run: uv sync --all-extras --dev
 
       # Install and run pre-commit
       - run: |
           uv run pre-commit install
           uv run pre-commit install --hook-type commit-msg
           uv run pre-commit run --all-files
 
   pytest:
     name: Pytest ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.12"]
         config:
           - { name: "Linux", os: ubuntu-latest }
-          - {
-              name: "MacOSX",
-              os: macos-latest
-            }
-          - {
-              name: "Windows",
-              os: windows-latest
-            }
+        # - {
+        #     name: "MacOSX",
+        #     os: macos-latest
+        #   }
+        # - {
+        #     name: "Windows",
+        #     os: windows-latest
+        #   }
 
     defaults:
       run:
         shell: bash
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+
+      # -----------------------------------------------------------------------
+      # Make that step a manual one and pushing files to the repo
+      # -----------------------------------------------------------------------
+      # - name: Install trame-vtk.js
+      #   run: |
+      #     bash .fetch_externals.sh
+      # -----------------------------------------------------------------------
+
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
           version: "0.8.12"
           enable-cache: true
 
+      - name: Install OSMesa for Linux
+        if: matrix.config.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libosmesa6-dev
+
       - name: Install and Run Tests
         run: |
           uv sync --dev
           uv pip install -r tests/requirements.txt
-          uv run pytest -s ./tests
+          uv run playwright install
+          uv run pytest -s ./tests --cov=src --cov-report=xml
+
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v3
+
+      - name: Upload pytest test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: pytest-results-${{  matrix.config.name }}
+          path: |
+            tests/refs/*.yml
+            tests/refs/**/*.png
+            assets/**
+          retention-days: 1
 
   release:
     needs: [pre-commit, pytest]
     runs-on: ubuntu-latest
-    environment: release
+    if: github.event_name == 'push'
+    environment:
+      name: pypi
+      url: https://pypi.org/p/trame
     permissions:
       id-token: write # IMPORTANT: mandatory for trusted publishing
       contents: write # IMPORTANT: mandatory for making GitHub Releases
+      attestations: write # IMPORTANT: mandatory for attest build provenance
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
+      - name: Install trame-vtk.js
+        run: |
+          bash .fetch_externals.sh
+
       - name: Python Semantic Release
         id: release
         uses: python-semantic-release/python-semantic-release@v10.5.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate artifact attestation for sdist and wheel
         if: steps.release.outputs.released == 'true'
         uses: actions/attest-build-provenance@v4.1.0
         with:
           subject-path: "dist/*"
 
       # https://docs.pypi.org/trusted-publishers/using-a-publisher/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish package distributions to PyPI
         if: steps.release.outputs.released == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
```