### PR TITLE
fix(vtk-module): route remaining serializer imports through vtk_module

### DIFF
--- a/src/trame_vtk/modules/vtk/serializers/data.py
+++ b/src/trame_vtk/modules/vtk/serializers/data.py
@@ -6,11 +6,11 @@ import sys
 vtk_module_name = os.environ.get("VTK_MODULE_NAME", "vtkmodules")
 sys.modules["vtk_module"] = importlib.import_module(vtk_module_name)
 
+from vtk_module.vtkCommonCore import vtkIdTypeArray  # noqa: E402
 from vtk_module.vtkFiltersGeometry import (  # noqa: E402
     vtkCompositeDataGeometryFilter,
     vtkDataSetSurfaceFilter,
 )
-from vtkmodules.vtkCommonCore import vtkIdTypeArray  # noqa: E402
 
 from .helpers import extract_required_fields, get_array_description  # noqa: E402
 from .registry import class_name  # noqa: E402

--- a/src/trame_vtk/modules/vtk/serializers/serialize.py
+++ b/src/trame_vtk/modules/vtk/serializers/serialize.py
@@ -8,9 +8,9 @@ sys.modules["vtk_module"] = importlib.import_module(vtk_module_name)
 
 from vtk_module.vtkCommonCore import vtkCommand  # noqa: E402
 
-from .cache import remove_from_cache
-from .registry import SERIALIZERS, class_name
-from .widgets import handle_widget
+from .cache import remove_from_cache  # noqa: E402
+from .registry import SERIALIZERS, class_name  # noqa: E402
+from .widgets import handle_widget  # noqa: E402
 
 __all__ = ["serialize", "serialize_widget"]
 

--- a/src/trame_vtk/modules/vtk/serializers/serialize.py
+++ b/src/trame_vtk/modules/vtk/serializers/serialize.py
@@ -1,6 +1,12 @@
+import importlib
 import logging
+import os
+import sys
 
-import vtk
+vtk_module_name = os.environ.get("VTK_MODULE_NAME", "vtkmodules")
+sys.modules["vtk_module"] = importlib.import_module(vtk_module_name)
+
+from vtk_module.vtkCommonCore import vtkCommand  # noqa: E402
 
 from .cache import remove_from_cache
 from .registry import SERIALIZERS, class_name
@@ -20,7 +26,7 @@ def serialize(parent, instance, instance_id, context, depth):
     serializer = SERIALIZERS.get(instance_type, None)
     if instance_id not in DELETE_CALLBACKS:
         instance.AddObserver(
-            vtk.vtkCommand.DeleteEvent, lambda *_a, **_k: remove(instance_id)
+            vtkCommand.DeleteEvent, lambda *_a, **_k: remove(instance_id)
         )
         DELETE_CALLBACKS.append(instance_id)
 

--- a/src/trame_vtk/modules/vtk/serializers/utils.py
+++ b/src/trame_vtk/modules/vtk/serializers/utils.py
@@ -1,7 +1,13 @@
 import base64
 import hashlib
+import importlib
+import os
+import sys
 
-from vtkmodules.util import numpy_support
+vtk_module_name = os.environ.get("VTK_MODULE_NAME", "vtkmodules")
+sys.modules["vtk_module"] = importlib.import_module(vtk_module_name)
+
+from vtk_module.util import numpy_support  # noqa: E402
 
 
 def rgb_float_to_hex(r, g, b):


### PR DESCRIPTION
`VTK_MODULE_NAME` (added in 448530a) only works for part of trame. Three imports in the vtk serializers still hardcode `vtkmodules`, so a custom VTK build gets used for some of the code and stock VTK for the rest.

`serializers/data.py` shows it best. It sets `vtk_module` on line 7, imports from it on line 9, then goes back to `vtkmodules` four lines later:

```python
vtk_module_name = os.environ.get("VTK_MODULE_NAME", "vtkmodules")
sys.modules["vtk_module"] = importlib.import_module(vtk_module_name)

from vtk_module.vtkFiltersGeometry import (...)
from vtkmodules.vtkCommonCore import vtkIdTypeArray   # missed
```

The other two are `serializers/utils.py` (`from vtkmodules.util import numpy_support`) and `serializers/serialize.py` (a bare `import vtk`).

**What it looks like in practice.** With a custom build and no stock `vtk` installed alongside it, the serializers don't import at all:

```
ModuleNotFoundError: No module named 'vtk'
```

If stock `vtk` is installed too, the import succeeds and you end up with objects from two VTK builds in one process. That fails later and further away, with errors like `TypeError: GetGlobalId argument 1:` and `TypeError: ExportLegacyFormat argument 1:`.

**Fix.** Same change as 090b504, applied to the three that were missed. `serialize.py` only used `vtk` for `vtk.vtkCommand.DeleteEvent`, so it becomes `from vtk_module.vtkCommonCore import vtkCommand`.

**Backwards compatibility.** The default is still `os.environ.get("VTK_MODULE_NAME", "vtkmodules")`, so nothing changes unless the variable is set. PyVista's jupyter/trame suite, three ways:

| setup | result |
|---|---|
| stock vtk, variable unset, before this PR | 56 passed |
| stock vtk, variable unset, after | 56 passed |
| custom build + `VTK_MODULE_NAME` set, after | 56 passed (all failed before) |

`vtk.vtkCommand is vtkmodules.vtkCommonCore.vtkCommand` is True, so the `serialize.py` change is a no-op on stock VTK. It also takes `import vtk` out of the serializer import path, which pulls in all of VTK: 384 ms against 48 ms for `vtkmodules.vtkCommonCore` on this machine.

**Left out.** `modules/paraview/protocols/mouse_handler.py` and `publish_image_delivery.py` have the same hardcoded `vtkWebCore` import. I didn't touch them since I have no way to test against ParaView. Happy to include them if you'd rather do it in one go.

Tested on Linux with Python 3.12 and 3.13, against stock VTK 9.6.2 and a custom 9.6.2 build. Not tested on Windows, macOS, or ParaView.

---

Attribution: this was investigated and written with Claude Opus 5.0. I reviewed the work and helped point it at the root cause, but the model did most of the digging and verification. I don't want to pass it off as solely my own.
